### PR TITLE
Made it actually do stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # cu-unis
 
-Aim: Generate a better directory for Columbia University, including an API.
+### Overview
+Added functionality to get all the unis and information of everyone at Columbia using Cunix. In a nut shell, every uni at columbia has a home directory within the cunix cloud. Scraping all the directory names returns all the unis that are in use at Columbia. This will **only work if run from cunix**
 
-Each student has a folder in UNIX where the title is their UNI.
+### Implementation
+This is a continuation of the research done by @fabiodesousa. His original work utilized the find command in order to list all the buckets but I improved performance by just using ```ls */*``` from the top level directory to get all the directory names and hence unis. From there, a lookup is done on every uni to grab the information on the individual from cunix. Some of the folder names are not valid unis and so will either return No information from the lookup or will open shell prompts which I automatically pass. 
 
-./  
-../u  
-../1 through 11  
-.../a through z  
-..../unis beginning with that letter  
-...../unique folder each student SSHs into  
+### Running
+Just run ```python ingest.py [format]``` with format being ```-csv``` or ```-json``` in order to output the data to a specific format. The default format with no flag is csv.
 
-By going into one of the numbered folders (e.g. /u/10), you can use a bash script to get all of the unis. Ex:
-
-find . -maxdepth 2 -type d > ../[number folder your uni is in]/[first letter of your uni]/[your uni]/[text file]
+### Notes
+* Not every field exists for every uni. Columbia undergrads tend to have departments while staff like maintenance does not. 
+* Don't use this for spam, it was made for research purposes

--- a/ingest.py
+++ b/ingest.py
@@ -1,0 +1,59 @@
+import os
+import json
+import csv
+import subprocess
+import sys
+
+os.system("ls /u/*/*/ > raw.txt")
+r = open("raw.txt")
+
+out_json = ("j" in sys.argv[1])
+count = 0
+total = 128000
+
+results = {} if out_json else []
+f = open('unis.json','wb') if out_json else open('unis.csv','wb')
+keys = set()
+for line in r:
+    count +=1
+    unis = filter(lambda x: ":" not in x, line.split())
+    for uni in unis:
+        print 1.0*count/total
+        if uni.isdigit() or not any(char.isdigit() for char in uni):
+            break
+
+        com = 'lookup '+ uni
+        print com
+
+        p = subprocess.Popen(["lookup", uni], stdout=subprocess.PIPE,stdin=subprocess.PIPE)
+        p.stdin.write('q')
+        out, err = p.communicate()
+        data = str(out)
+        
+        if not data or data[0] != "-":
+            break
+        else:
+            row = {}
+            k = None
+            v = ''
+            for chunk in data.split('\n'):
+                for part in chunk.replace("--","").split():
+                    if ":" in part:
+                        if k is not None:
+                            row[k] = v.replace('\n', ' ').replace(',', '')
+                            v = ''
+                        k = part.strip().replace(":","")
+                        keys.add(k)
+                    else:
+                        v  = v + " " + part
+            if out_json:
+                results[uni] = row
+            else:
+                results.append(row)
+
+if out_json:
+    json.dump(results, f)
+else:
+    w = csv.DictWriter(f, keys)
+    w.writerows(results)
+    f.close()

--- a/undergrads.py
+++ b/undergrads.py
@@ -1,0 +1,11 @@
+import json
+from collections import defaultdict
+
+histogram = defaultdict(int)
+with open('/u/5/n/nl2418/cu-unis/unis.json') as data_file:
+    unis = json.load(data_file)
+for uni in unis.keys():
+    info = unis[uni]
+    histogram[info.get('Dept','')] +=1 
+for key in sorted(histogram.keys()):
+    print key, histogram[key]


### PR DESCRIPTION
~~~ I'm going to make a push to have this added to the README as well ~~
### Overview

Added functionality to get all the unis and information of everyone at Columbia using Cunix. In a nut shell, every uni at columbia has a home directory within the cunix cloud. Scraping all the directory names returns all the unis that are in use at Columbia. This will **only work if run from cunix**
### Implementation

This is a continuation of the research done by @fabiodesousa. His original work utilized the find command in order to list all the buckets but I improved performance by just using `ls */*` from the top level directory to get all the directory names and hence unis. From there, a lookup is done on every uni to grab the information on the individual from cunix. Some of the folder names are not valid unis and so will either return No information from the lookup or will open shell prompts which I automatically pass. 
### Running

Just run `python ingest.py [format]` with format being `-csv` or `-json` in order to output the data to a specific format. The default format with no flag is csv.
### Notes
- Not every field exists for every uni. Columbia undergrads tend to have departments while staff like maintenance does not. 
- Don't use this for spam, it was made for research purposes
